### PR TITLE
Check that student_answers exists in a given problem state - was fail…

### DIFF
--- a/edx2bigquery/make_problem_analysis.py
+++ b/edx2bigquery/make_problem_analysis.py
@@ -151,6 +151,9 @@ def make_problem_analysis(course_id, basedir=None, datedir=None, force_recompute
         if not state['correct_map']:    # correct map = {} is not of interest
             continue
 
+        if 'student_answers' not in state:  #'student_answers' did not exist in some Davidson courses
+            continue
+            
         answers = state['student_answers']
 
         items = []


### PR DESCRIPTION
Problem analysis was failing for Davidson Next courses. "student_answers" did not appear in some problem states. Note yet 100% sure which problems, but my feeling is that the new "problem-builder" package that allows for free text entry is the culprit. For now, this PR allows the problem_analysis to continue for those states that do contain "student_answers".
