### PR TITLE
Updated 'rephrase_tracking_logs' to account for Null values in change_video_speed events

### DIFF
--- a/edx2bigquery/edx2course_axis.py
+++ b/edx2bigquery/edx2course_axis.py
@@ -343,9 +343,9 @@ def make_axis(dir):
 
                 # meta will store all problem related metadata, then be used to update data
                 meta = {}
-                # Parts is meant to help debug - an ordered list of encountered problem types with url names
+                # Items is meant to help debug - an ordered list of encountered problem types with url names
                 # Likely should not be pulled to Big Query 
-                meta['parts'] = []
+                meta['items'] = []
                 # Known Problem Types
                 known_problem_types = ['multiplechoiceresponse','numericalresponse','choiceresponse',
                                        'optionresponse','stringresponse','formularesponse',
@@ -354,7 +354,7 @@ def make_axis(dir):
                 # Loop through all child nodes in a problem. If encountering a known problem type, add metadata.
                 for a in x:
                     if a.tag in known_problem_types:
-                        meta['parts'].append({'ptype':a.tag,'url_name':a.get('url_name')})
+                        meta['items'].append({'itype':a.tag,'url_name':a.get('url_name')})
 
                     # Check for a solution - can eventually be updated to contain more descriptive information
                     if a.tag == 'solution':
@@ -364,34 +364,34 @@ def make_axis(dir):
                             ### Low stakes check for solution (65 char). We could feasibly just store the solution text.
                             ### 65 is roughly the number of html element characters in a default solution template.
                             if len(text) > 65:
-                                meta['solution'] = True
+                                meta['has_solution'] = True
                     
                     # Check for accompanying image
                     if a.tag == 'img':
-                        meta['image'] = True #Note, one can use a.get('src'), but needs to account for multiple images
+                        meta['has_image'] = True #Note, one can use a.get('src'), but needs to account for multiple images
 
                 ### If meta is empty, log all tags for debugging later. 
                 if len(meta)==0:
-                    logit('problem type not found - here is the list of tags:['+','.join(a.tag if a else ' ' for a in x)+']')
+                    logit('item type not found - here is the list of tags:['+','.join(a.tag if a else ' ' for a in x)+']')
                     # print 'problem type not found - here is the list of tags:['+','.join(a.tag for a in x)+']'
 
                 ### Add easily accessible metadata for problems
-                # num_parts: number of parts
-                # ptype: problem type - note, mixed is used when parts are not of same type
-                if len(meta['parts']) > 0:
-                    # Number of Parts
-                    meta['num_parts'] = len(meta['parts'])
+                # num_items: number of items
+                # itype: problem type - note, mixed is used when items are not of same type
+                if len(meta['items']) > 0:
+                    # Number of Items
+                    meta['num_items'] = len(meta['items'])
 
                     # Problem Type
-                    if all(meta['parts'][0]['ptype'] == item['ptype'] for item in meta['parts']):
-                        meta['ptype'] = meta['parts'][0]['ptype']
-                        # print meta['parts'][0]['ptype']
+                    if all(meta['items'][0]['itype'] == item['itype'] for item in meta['items']):
+                        meta['itype'] = meta['items'][0]['itype']
+                        # print meta['items'][0]['itype']
                     else:
-                        meta['ptype'] = 'mixed'
+                        meta['itype'] = 'mixed'
 
                 # Update data field
-                ### ! For now, removing the parts field. 
-                del meta["parts"]               
+                ### ! For now, removing the items field. 
+                del meta["items"]               
 
                 data.update(meta)
                 data = json.dumps(data)

--- a/edx2bigquery/make_problem_analysis.py
+++ b/edx2bigquery/make_problem_analysis.py
@@ -135,7 +135,13 @@ def make_problem_analysis(course_id, basedir=None, datedir=None, force_recompute
         # May 2015: new location syntax for module_id's, e.g.:
         # block-v1:HarvardX+BUS5.1x+3T2015+type@sequential+block@34c9c30a2bd3486f9e63e18552818286
 
-        (org, num, category, url_name) = mid.rsplit('/',3)
+        if mid.count('+') >= 4:
+            (org, num, run, category, url_name) = mid.rsplit('+',4)
+            if 'problem' in category:
+                category = 'problem'
+        else:
+            (org, num, category, url_name) = mid.rsplit('/',3)
+
         if not category=='problem':     # filter based on category info in module_id
             continue
         try:

--- a/edx2bigquery/make_problem_analysis.py
+++ b/edx2bigquery/make_problem_analysis.py
@@ -135,12 +135,7 @@ def make_problem_analysis(course_id, basedir=None, datedir=None, force_recompute
         # May 2015: new location syntax for module_id's, e.g.:
         # block-v1:HarvardX+BUS5.1x+3T2015+type@sequential+block@34c9c30a2bd3486f9e63e18552818286
 
-        if mid.count('+') >= 4:
-            (org, num, run, category, url_name) = mid.rsplit('+',4)
-            if 'problem' in category:
-                category = 'problem'
-        else:
-            (org, num, category, url_name) = mid.rsplit('/',3)
+        (org, num, category, url_name) = mid.rsplit('/',3)
 
         if not category=='problem':     # filter based on category info in module_id
             continue

--- a/edx2bigquery/rephrase_tracking_logs.py
+++ b/edx2bigquery/rephrase_tracking_logs.py
@@ -31,6 +31,7 @@ import gzip
 import string
 import datetime
 import traceback
+from math import isnan
 from path import path
 from addmoduleid import add_module_id
 from check_schema_tracking_log import check_schema
@@ -295,7 +296,7 @@ def do_rephrase(data, do_schema_check=True, linecnt=0):
             # First check if string is float
             if string_is_float(data['event_struct']['new_speed']):
                 # Second check if value is null
-                if float(data['event_struct']['new_speed']) != float(data['event_struct']['new_speed']):
+                if isnan(float(data['event_struct']['new_speed'])):
                     data['event_struct'].pop('new_speed')
 
 

--- a/edx2bigquery/rephrase_tracking_logs.py
+++ b/edx2bigquery/rephrase_tracking_logs.py
@@ -281,20 +281,22 @@ def do_rephrase(data, do_schema_check=True, linecnt=0):
     #-----------------------------------------
     # check for null values in speed_change_video
     # Error encountered parsing LAC data from Oct. 2013
+    # Requires that we also be able to convert the value to a float
 
-    def check_empty_value(data_dict, *keys):
-        key = keys[0]
-        if type(data_dict)==dict and key in data_dict:
-            if len(keys)==1:
-                if float(data_dict[key]) != float(data_dict[key]):
-                    print data_dict[key]
-                    data_dict.pop(key)
-            else:
-                check_empty_value(data_dict[key], *keys[1:])
+    def string_is_float(s):
+        try:
+            float(s)
+            return True
+        except ValueError:
+            return False
 
     if data['event_type']=='speed_change_video':
-        if 'event_struct' in data:
-            check_empty_value(data['event_struct'],'new_speed')
+        if 'event_struct' in data and 'new_speed' in data['event_struct']:
+            # First check if string is float
+            if string_is_float(data['event_struct']['new_speed']):
+                # Second check if value is null
+                if float(data['event_struct']['new_speed']) != float(data['event_struct']['new_speed']):
+                    data['event_struct'].pop('new_speed')
 
 
     # check for any funny keys, recursively

--- a/edx2bigquery/rephrase_tracking_logs.py
+++ b/edx2bigquery/rephrase_tracking_logs.py
@@ -278,6 +278,25 @@ def do_rephrase(data, do_schema_check=True, linecnt=0):
 
     data.pop('event_js')	# leftover from mongo import script
 
+    #-----------------------------------------
+    # check for null values in speed_change_video
+    # Error encountered parsing LAC data from Oct. 2013
+
+    def check_empty_value(data_dict, *keys):
+        key = keys[0]
+        if type(data_dict)==dict and key in data_dict:
+            if len(keys)==1:
+                if float(data_dict[key]) != float(data_dict[key]):
+                    print data_dict[key]
+                    data_dict.pop(key)
+            else:
+                check_empty_value(data_dict[key], *keys[1:])
+
+    if data['event_type']=='speed_change_video':
+        if 'event_struct' in data:
+            check_empty_value(data['event_struct'],'new_speed')
+
+
     # check for any funny keys, recursively
     funny_key_sections = []
     def check_for_funny_keys(entry, name='toplevel'):

--- a/edx2bigquery/schemas/schema_course_axis.json
+++ b/edx2bigquery/schemas/schema_course_axis.json
@@ -58,22 +58,42 @@
                         {
                             "type": "STRING", 
                             "name": "ytid",
-			    "description": "youtube ID of video element, or of youtube video within an iframe in an HTML element"
+			                "description": "youtube ID of video element, or of youtube video within an iframe in an HTML element"
                         },
                         {
                             "type": "FLOAT", 
                             "name": "weight",
-			    "description": "grading weight (for problems)"
+			                "description": "grading weight (for problems)"
                         },
                         {
                             "type": "STRING", 
                             "name": "group_id_to_child",
-			    "description": "children in A/B test partition (for split_test)"
+			                "description": "children in A/B test partition (for split_test)"
                         },
                         {
                             "type": "STRING", 
                             "name": "user_partition_id",
-			    "description": "A/B user partition ID (for split_test)"
+			                "description": "A/B user partition ID (for split_test)"
+                        },
+                        {
+                            "type": "STRING", 
+                            "name": "ptype",
+                            "description": "Problem type for problems found in course.xml - only searches within a list of known problem types"
+                        },
+                        {
+                            "type": "INTEGER", 
+                            "name": "num_parts",
+                            "description": "Number of problem sub-parts, or the number of ptypes found in a single problem"
+                        },
+                        {
+                            "type": "BOOLEAN", 
+                            "name": "solution",
+                            "description": "Boolean as to whether a solution exists in the problem."
+                        },
+                        {
+                            "type": "BOOLEAN", 
+                            "name": "image",
+                            "description": "Boolean as to whether the problem contains an image."
                         }
                     ] 
         },

--- a/edx2bigquery/schemas/schema_course_axis.json
+++ b/edx2bigquery/schemas/schema_course_axis.json
@@ -77,22 +77,22 @@
                         },
                         {
                             "type": "STRING", 
-                            "name": "ptype",
+                            "name": "itype",
                             "description": "Problem type for problems found in course.xml - only searches within a list of known problem types"
                         },
                         {
                             "type": "INTEGER", 
-                            "name": "num_parts",
+                            "name": "num_items",
                             "description": "Number of problem sub-parts, or the number of ptypes found in a single problem"
                         },
                         {
                             "type": "BOOLEAN", 
-                            "name": "solution",
+                            "name": "has_solution",
                             "description": "Boolean as to whether a solution exists in the problem."
                         },
                         {
                             "type": "BOOLEAN", 
-                            "name": "image",
+                            "name": "has_image",
                             "description": "Boolean as to whether the problem contains an image."
                         }
                     ] 


### PR DESCRIPTION
1. Updated 'rephrase_tracking_logs' to account for Null values in speed_change_video fields in the logs. Method is now specialized to only focus on the speed_change_video field.
2. Added item metadata to the course axis file using the existing data field. Data now contains the following values for "category==problem":
   a. itype - type of item, e.g., multiplechoiceresponse. 
   b. num_items - total number of items within the problem. Problems can contain multiple parts for a single submit button.
   c. has_solution - Boolean indicating whether a solution exists 
   d. has_image - Boolean indicating whether an image exists in the problem.
- Note in make_problem_analysis - seems I was doing some debugging on August 27th related to module IDs, but nothing came of it. Make sure nothing effects your base.
