### PR TITLE
Add child_count to schema

### DIFF
--- a/edx2bigquery/schemas/schema_forum.json
+++ b/edx2bigquery/schemas/schema_forum.json
@@ -71,6 +71,10 @@
             "name": "abuse_flaggers"
         }, 
         {
+            "type": "INTEGER", 
+            "name": "child_count"
+        }, 
+        {
             "type": "BOOLEAN", 
             "name": "visible"
         }, 


### PR DESCRIPTION
seems like edx added a child_count was causing rephrase_forum_data.py to fail.
