### PR TITLE
Updated regex so that it applies to courses from UBC LTI

### DIFF
--- a/edx2bigquery/addmoduleid.py
+++ b/edx2bigquery/addmoduleid.py
@@ -57,6 +57,7 @@ cidre10 = re.compile('/courses/(?P<org>[^/]+)/(?P<course>[^/]+)/(?P<semester>[^+
 
 # "page": "https://courses.edx.org/courses/MITx/6.00.1x_5/1T2015/courseware/d5d822451677476fbfb0a0f9a14e0501/bbc2f0aa5bc54bf8ba2f6c36391202fb/",
 # "event": "input_i4x-MITx-6_00_1x_5-problem-5bada2f1e64249f996ee1a37df8db810_2_1=..."
+
 cidre11 = re.compile('/courses/(?P<org>[^/]+)/(?P<course>[^/]+)/(?P<semester>[^+]+)/courseware/(?P<chapter>[^/]+)/(?P<sequential>[^/]+)/')
 cidre11a = re.compile('input_i4x-(?P<org>[^-]+?)-(?P<course>[^-]+?)-(?P<mtype>[^-]+?)-(?P<id>.+?)_[0-9]+_[^=]+=.*')
 
@@ -118,7 +119,7 @@ okre1 = re.compile('/courses/course-v1:(?P<org>[^+]+)\+(?P<course>[^+]+)\+(?P<se
 # "event": "\"input_Blocks_on_Ramp_randxyzBILNKOA0_2_1=choice_3\""
 # "event_type": "problem_check"
 
-okre2 = re.compile('/courses/course-v1:(?P<org>[^+]+)\+(?P<course>[^+]+)\+(?P<semester>[^+]+)/courseware')
+okre2 = re.compile('/courses/course-v1:(?P<org>[^+]+)\+(?P<course>[^+]+)\+(?P<semester>[^+]+)/[bc]')
 okre2a = re.compile('input_(?P<id>[^=]+)_[0-9]+_[^=]+=')
 
 # "event_type": "/courses/course-v1:MITx+CTL.SC1x_1+2T2015/xblock/block-v1:MITx+CTL.SC1x_1+2T2015+type@sequential+block@5aff08b86e0e431e8ef29b0fbe52ecb


### PR DESCRIPTION
The issue is UBC specific but it works for all. We ran into problems when courses are from LTI 
the regex:
okre2 = re.compile('/courses/course-v1:(?P<org>[^+]+)+(?P<course>[^+]+)+(?P<semester>[^+]+)/**courseware**’)
courses successfully parsed:
https://edge.edx.org/courses/course-v1:UBC+PHYS100-98A+2016SA/**courseware**/38890515870e437590e2c6222628d6d6/ab4d4b5dd89a49478d434506cfd78da9/
not successfully parsed:
https://edx-lti.org/lti_provider/courses/course-v1:UBC+CIVL200-98A+2016SA/**block**-v1:UBC+CIVL200-98A+2016SA+type@sequential+block@f24567248e3c456c91620b8dc814806d/

Changed regex to 
okre2 = re.compile('/courses/course-v1:(?P<org>[^+]+)+(?P<course>[^+]+)+(?P<semester>[^+]+)/**[bc]**’)
so it applies to courses from all the sources
Already been tested for months.
