### PR TITLE
Update schema_tracking_log.json

### DIFF
--- a/edx2bigquery/schemas/schema_tracking_log.json
+++ b/edx2bigquery/schemas/schema_tracking_log.json
@@ -193,6 +193,10 @@
                             "name": "done"
                         }, 
                         {
+                            "type": "BOOLEAN", 
+                            "name": "has_saved_answers"
+                        }, 
+                        {
                             "type": "STRING", 
                             "name": "correct_map"
                         }, 


### PR DESCRIPTION
A new schema item has been added to the edx tracking log files: has_saved_answers

Split currently throws the following error:
Exception: [check_schema] Oops! field has_saved_answers is not in the schema, linecnt=0, path=/event_struct/state

The schema_tracking_log.json file was updated to insert this boolean schema item.
