### PR TITLE
Don't use depreciated path.py import

### DIFF
--- a/edx2bigquery/analyze_content.py
+++ b/edx2bigquery/analyze_content.py
@@ -10,7 +10,7 @@ import datetime
 
 from collections import defaultdict, OrderedDict
 from lxml import etree
-from path import path
+from path import Path as path
 from load_course_sql import find_course_sql_dir
 from make_geoip_table import lock_file
 

--- a/edx2bigquery/axis2bigquery.py
+++ b/edx2bigquery/axis2bigquery.py
@@ -10,7 +10,7 @@ import gsutil
 import bqutil
 import copy
 import datetime
-from path import path
+from path import Path as path
 from check_schema_tracking_log import check_schema, schema2dict
 
 def already_exists(course_id, use_dataset_latest=False):

--- a/edx2bigquery/check_course_key_version.py
+++ b/edx2bigquery/check_course_key_version.py
@@ -5,7 +5,7 @@
 import gzip
 import glob
 import gsutil
-from path import path
+from path import Path as path
 
 def course_key_version(course_id, logs_dir="TRACKING_LOGS", verbose=False):
 

--- a/edx2bigquery/do_waldofication_of_sql.py
+++ b/edx2bigquery/do_waldofication_of_sql.py
@@ -2,7 +2,7 @@ import os, sys, glob
 import re
 import gzip
 
-from path import path
+from path import Path as path
 
 #-----------------------------------------------------------------------------
 

--- a/edx2bigquery/edx2course_axis.py
+++ b/edx2bigquery/edx2course_axis.py
@@ -46,7 +46,7 @@ import xbundle
 import tempfile
 from collections import namedtuple, defaultdict
 from lxml import etree,html
-from path import path
+from path import Path as path
 from fix_unicode import fix_bad_unicode
 
 DO_SAVE_TO_MONGO = False

--- a/edx2bigquery/extract_logs_mongo2gs.py
+++ b/edx2bigquery/extract_logs_mongo2gs.py
@@ -6,7 +6,7 @@
 
 import os, sys
 import datetime
-from path import path
+from path import Path as path
 from gsutil import get_gs_file_list, gs_path_from_course_id, path_from_course_id, upload_file_to_gs
 
 DBNAME = 'harvardxdb'

--- a/edx2bigquery/fix_missing_grades.py
+++ b/edx2bigquery/fix_missing_grades.py
@@ -11,7 +11,7 @@ except:
     from edxcut import edxapi
 import datetime
 
-from path import path
+from path import Path as path
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir, parseCourseIdField

--- a/edx2bigquery/fix_missing_user_info.py
+++ b/edx2bigquery/fix_missing_user_info.py
@@ -5,7 +5,7 @@ import gzip
 import json
 import gsutil
 
-from path import path
+from path import Path as path
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir

--- a/edx2bigquery/gsutil.py
+++ b/edx2bigquery/gsutil.py
@@ -5,7 +5,7 @@
 
 import os, sys
 import dateutil.parser
-from path import path
+from path import Path as path
 from collections import OrderedDict
 import datetime
 import pytz

--- a/edx2bigquery/load_course_sql.py
+++ b/edx2bigquery/load_course_sql.py
@@ -33,7 +33,7 @@ import gzip
 import bqutil
 import gsutil
 import unicodecsv as csv
-from path import path
+from path import Path as path
 from gsutil import get_gs_file_list
 
 #-----------------------------------------------------------------------------

--- a/edx2bigquery/main.py
+++ b/edx2bigquery/main.py
@@ -13,7 +13,7 @@ import traceback
 import datetime
 import multiprocessing as mp
 
-from path import path
+from path import Path as path
 
 from argparse import RawTextHelpFormatter
 from collections import OrderedDict

--- a/edx2bigquery/make_combined_person_course.py
+++ b/edx2bigquery/make_combined_person_course.py
@@ -3,7 +3,7 @@
 import os, sys
 import json
 import datetime
-from path import path
+from path import Path as path
 import gsutil
 import bqutil
 

--- a/edx2bigquery/make_enrollment_day.py
+++ b/edx2bigquery/make_enrollment_day.py
@@ -23,7 +23,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from gsutil import get_gs_file_list
 
 

--- a/edx2bigquery/make_forum_analysis.py
+++ b/edx2bigquery/make_forum_analysis.py
@@ -12,7 +12,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from collections import OrderedDict
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema

--- a/edx2bigquery/make_grades_persistent.py
+++ b/edx2bigquery/make_grades_persistent.py
@@ -13,7 +13,7 @@ import bqutil
 
 import unicodecsv as csv
 
-from path import path
+from path import Path as path
 import load_course_sql
 
 

--- a/edx2bigquery/make_grading_policy_table.py
+++ b/edx2bigquery/make_grading_policy_table.py
@@ -4,7 +4,7 @@ import re
 import tarfile
 
 import unicodecsv as csv
-from path import path
+from path import Path as path
 
 import bqutil
 import gsutil

--- a/edx2bigquery/make_openassessment_analysis.py
+++ b/edx2bigquery/make_openassessment_analysis.py
@@ -14,7 +14,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir, openfile

--- a/edx2bigquery/make_person_course.py
+++ b/edx2bigquery/make_person_course.py
@@ -64,7 +64,7 @@ import bqutil
 import gsutil
 import datetime
 import copy
-from path import path
+from path import Path as path
 from collections import OrderedDict, defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir, get_course_sql_dirdate

--- a/edx2bigquery/make_person_course_day.py
+++ b/edx2bigquery/make_person_course_day.py
@@ -57,7 +57,7 @@ import sys
 import json
 import bqutil
 import datetime
-from path import path
+from path import Path as path
 from gsutil import get_gs_file_list
 
 import process_tracking_logs

--- a/edx2bigquery/make_problem_analysis.py
+++ b/edx2bigquery/make_problem_analysis.py
@@ -20,7 +20,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir, openfile

--- a/edx2bigquery/make_roles.py
+++ b/edx2bigquery/make_roles.py
@@ -37,7 +37,7 @@ import json
 import gsutil
 import pandas as pd
 
-from path import path
+from path import Path as path
 from collections import defaultdict, OrderedDict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir

--- a/edx2bigquery/make_time_on_task.py
+++ b/edx2bigquery/make_time_on_task.py
@@ -28,7 +28,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from gsutil import get_gs_file_list
         
 #-----------------------------------------------------------------------------

--- a/edx2bigquery/make_user_info_combo.py
+++ b/edx2bigquery/make_user_info_combo.py
@@ -53,7 +53,7 @@ import gzip
 import json
 import gsutil
 
-from path import path
+from path import Path as path
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema
 from load_course_sql import find_course_sql_dir

--- a/edx2bigquery/make_video_analysis.py
+++ b/edx2bigquery/make_video_analysis.py
@@ -12,7 +12,7 @@ import bqutil
 import datetime
 import process_tracking_logs
 
-from path import path
+from path import Path as path
 from collections import OrderedDict
 from collections import defaultdict
 from check_schema_tracking_log import schema2dict, check_schema

--- a/edx2bigquery/rephrase_forum_data.py
+++ b/edx2bigquery/rephrase_forum_data.py
@@ -22,7 +22,7 @@ import traceback
 from addmoduleid import add_module_id
 from check_schema_tracking_log import check_schema, schema2dict
 from load_course_sql import find_course_sql_dir
-from path import path
+from path import Path as path
 from edx2course_axis import date_parse
 import bqutil
 import gsutil

--- a/edx2bigquery/rephrase_tracking_logs.py
+++ b/edx2bigquery/rephrase_tracking_logs.py
@@ -32,7 +32,7 @@ import string
 import datetime
 import traceback
 from math import isnan
-from path import path
+from path import Path as path
 from addmoduleid import add_module_id
 from check_schema_tracking_log import check_schema
 

--- a/edx2bigquery/run_external.py
+++ b/edx2bigquery/run_external.py
@@ -11,7 +11,7 @@ import json
 import re
 
 from jinja2 import Template
-from path import path
+from path import Path as path
 
 def run_external_script(extcmd, param, ecinfo, course_id):
     """

--- a/edx2bigquery/transfer_logs_to_gs.py
+++ b/edx2bigquery/transfer_logs_to_gs.py
@@ -23,7 +23,7 @@ import glob
 import datetime
 import pytz
 import dateutil.parser
-from path import path
+from path import Path as path
 import gsutil
 
 def process_dir(course_id, gspath='gs://x-data', logs_directory="TRACKING_LOGS", verbose=True):

--- a/edx2bigquery/xbundle.py
+++ b/edx2bigquery/xbundle.py
@@ -23,7 +23,7 @@ import glob
 
 from lxml import etree
 from lxml.html.soupparser import fromstring as fsbs
-from path import path	# needs path.py
+from path import Path as path	# needs path.py
 
 #-----------------------------------------------------------------------------
 

--- a/edx2bigquery_config.py.template
+++ b/edx2bigquery_config.py.template
@@ -48,7 +48,7 @@ extra_external_commands = {}
 # Instuctor level access is required 
 #-------------------------------------------
 import os, sys
-from path import path
+from path import Path as path
 
 # Store username and password in a protected, private path
 # create new file called edx_private_config.py 


### PR DESCRIPTION
Resolves #63.

Changes all import statements `from path import path` to `from path import Path`.

This is due to `path.path` being depreciated in favor of `path.Path` in the [path.py](https://github.com/jaraco/path.py) library dependency as of January 2017, which causes an ImportError for all edx2bigquery commands for edx2bigquery installations that use recent versions of path.py .