### PR TITLE
Add note on installing edxcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ To get started, install the Google Cloud SDK first:
 Then generate authentication tokens using "gcloud auth login". Make sure
 that "bq" and "gsutil" work properly.
 
+Install edxcut dependency:
+```
+git clone https://github.com/mitodl/edxcut.git
+pip install ./edxcut
+```
+
 To install:
 
   python setup.py develop


### PR DESCRIPTION
Resolves #62.

Adds note to README to install edxcut from github source, rather than defaulting to installing from pypi, due to setup issue with the current source distribution on pypi (mitodl/edx2bigquery#62).
