### PR TITLE
Make generated tempfile generated files both user and group accessible

### DIFF
--- a/edx2bigquery/rephrase_forum_data.py
+++ b/edx2bigquery/rephrase_forum_data.py
@@ -18,6 +18,7 @@ import unicodecsv as csv
 import gzip
 import string
 import datetime
+import stat
 import traceback
 import tempfile
 
@@ -216,6 +217,7 @@ def rephrase_forum_json_for_course(course_id, gsbucket="gs://x-data",
 
     cnt = 0
     tmp_fd, tmp_fname = tempfile.mkstemp(dir=mypath, prefix='{p}_'.format(p=os.getpid()), suffix='_tmp.json.gz')
+    os.fchmod(tmp_fd, stat.S_IRWXG | stat.S_IRWXU)
     ofp = gzip.GzipFile(fileobj=os.fdopen(tmp_fd, 'w'))
     data = OrderedDict()
     for line in fp:

--- a/edx2bigquery/rephrase_forum_data.py
+++ b/edx2bigquery/rephrase_forum_data.py
@@ -217,7 +217,7 @@ def rephrase_forum_json_for_course(course_id, gsbucket="gs://x-data",
 
     cnt = 0
     tmp_fd, tmp_fname = tempfile.mkstemp(dir=mypath, prefix='{p}_'.format(p=os.getpid()), suffix='_tmp.json.gz')
-    os.fchmod(tmp_fd, stat.S_IRWXG | stat.S_IRWXU)
+    os.fchmod(tmp_fd, stat.S_IRWXG | stat.S_IRWXU | stat.S_IROTH)
     ofp = gzip.GzipFile(fileobj=os.fdopen(tmp_fd, 'w'))
     data = OrderedDict()
     for line in fp:


### PR DESCRIPTION
Because `tempfile.mkstemp` generates files only accessible by the process user ID, I added a line with `os.fchmod` to make the generated files both user and group accessible.

Thanks!